### PR TITLE
Prevent picking user twice on reroll

### DIFF
--- a/src/events/reRoll.ts
+++ b/src/events/reRoll.ts
@@ -41,10 +41,10 @@ export const reRoll: Middleware<
     return throwUnexpectedError(client, channel, body.message.ts);
   }
 
-  // TODO exclude originally picked user w/ pickedUser?
-  const { triggerTs, triggerUser, teamId, excludedInPick } = JSON.parse(
-    action.value,
-  ) as PickButtonPayload;
+  const { triggerTs, triggerUser, teamId, excludedInPick, pickedUser } =
+    JSON.parse(action.value) as PickButtonPayload;
+
+  const excludedUsersAndPickedUser = [...excludedInPick, pickedUser];
 
   // Hide re-roll button
   if (Array.isArray(blocks) && isSectionBlock(blocks[0])) {
@@ -74,7 +74,7 @@ export const reRoll: Middleware<
     context,
     triggerTs,
     client,
-    excludedInPick,
+    excludedUsersAndPickedUser,
     teamId,
   );
 };


### PR DESCRIPTION
I realised adding the ability to prevent picking users twice was fairly trivial with the previous change to excluded users. This adds people to the list of excluded users when they've been picked, so they won't be picked again.