### PR TITLE
Prevent picking user twice on reroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Note that one must currently call the exclude tag after the team tag, if both ar
 | `:user_error:` | User error |
 | `:confusedparrot:` | Unexpected error|
 
+## Re-rolling
+The picker has the ability to re-roll by clicking the "Re-roll" button under the last picked user in the slack thread. Re-rolling will exclude previously-picked users, until there are no more users to pick.
+
 ## What's next
 
 - Avoid picking recently picked users

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 ## Usage
 
-| Command | Description | Example |
-| --- | --- | --- |
-| `pick <message>` | Pick a non-excluded user from the channel.<br>Pickir will never pick the picker. | `@Pickir pick TFGM-123: This is a test` |
-| `[exclude \| rm] @User` | Exclude the user from **all** picks.<br>Note that by default all users are included. | `@Pickir exclude @Alex Yip` |
-| `[include \| i] @User` | Re-include the user from picks. | `@Pickir include @Alex Yip` |
-| `[list-excluded \| lse]` | List and manage excluded users. | `@Pickir lse` |
-| `create <team name>` | Create team with the given team name and manage members.<br>Team names are case-insensitive. | `@Pickir create a-team` |
-| `show <team name>` | Show team and manage members. | `@Pickir show a-team` |
-| `stats` | This is a WIP feature.<br>Show statistics for the current channel.  | `@Pickir stats` |
+| Command                  | Description                                                                                  | Example                                 |
+|--------------------------|----------------------------------------------------------------------------------------------|-----------------------------------------|
+| `pick <message>`         | Pick a non-excluded user from the channel.<br>Pickir will never pick the picker.             | `@Pickir pick TFGM-123: This is a test` |
+| `[exclude \| rm] @User`  | Exclude the user from **all** picks.<br>Note that by default all users are included.         | `@Pickir exclude @Alex Yip`             |
+| `[include \| i] @User`   | Re-include the user from picks.                                                              | `@Pickir include @Alex Yip`             |
+| `[list-excluded \| lse]` | List and manage excluded users.                                                              | `@Pickir lse`                           |
+| `create <team name>`     | Create team with the given team name and manage members.<br>Team names are case-insensitive. | `@Pickir create a-team`                 |
+| `show <team name>`       | Show team and manage members.                                                                | `@Pickir show a-team`                   |
+| `stats`                  | This is a WIP feature.<br>Show statistics for the current channel.                           | `@Pickir stats`                         |
 
 ## Extra flags for picks
+
 Note that one must currently call the exclude tag after the team tag, if both are provided.
 
 | flag                                      | Description                  |
@@ -20,16 +21,17 @@ Note that one must currently call the exclude tag after the team tag, if both ar
 | `--team <team name>`, (`-t`)              | Only pick from specific team |
 | `--exclude @Ned Reid @Sned Sreid`, (`-e`) | Exclude users                |
 
-
 ## Error handling
 
-| Pickir's reaction | Description |
-| --- | --- |
-| `:user_error:` | User error |
-| `:confusedparrot:` | Unexpected error|
+| Pickir's reaction  | Description      |
+|--------------------|------------------|
+| `:user_error:`     | User error       |
+| `:confusedparrot:` | Unexpected error |
 
 ## Re-rolling
-The picker has the ability to re-roll by clicking the "Re-roll" button under the last picked user in the slack thread. Re-rolling will exclude previously-picked users, until there are no more users to pick.
+
+The picker can re-roll by clicking the "Re-roll" button under the last picked user in the slack thread.
+Re-rolling will exclude previously-picked users, until there are no more users to pick.
 
 ## What's next
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mention-bot",
+  "name": "pickir-bot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mention-bot",
+      "name": "pickir-bot",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mention-bot",
+  "name": "pickir-bot",
   "version": "1.0.0",
   "description": "",
   "main": "app.ts",

--- a/src/events/reRoll.ts
+++ b/src/events/reRoll.ts
@@ -41,10 +41,10 @@ export const reRoll: Middleware<
     return throwUnexpectedError(client, channel, body.message.ts);
   }
 
-  // TODO exclude originally picked user w/ pickedUser?
-  const { triggerTs, triggerUser, teamId, excludedInPick } = JSON.parse(
-    action.value,
-  ) as PickButtonPayload;
+  const { triggerTs, triggerUser, teamId, excludedInPick, pickedUser } =
+    JSON.parse(action.value) as PickButtonPayload;
+
+  const excludedUsersAndPickedUser = [...excludedInPick, pickedUser];
 
   // Hide re-roll button
   if (Array.isArray(blocks) && isSectionBlock(blocks[0])) {
@@ -74,7 +74,7 @@ export const reRoll: Middleware<
     context,
     triggerTs,
     client,
-    excludedInPick,
+    excludedUsersAndPickedUser,
     teamId,
   );
 };


### PR DESCRIPTION
I realised adding the ability to prevent picking users twice was fairly trivial with the previous change to excluded users. This adds people to the list of excluded users when they've been picked, so they won't be picked again.

_Closed and re-submitted in order to change the source branch_